### PR TITLE
Canonicalize lib names in deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
-{:deps  {org.clojure/clojure       {:mvn/version "1.10.0"}
-         org.clojure/clojurescript {:mvn/version "1.10.339"}
-         reagent                   {:mvn/version "0.10.0"}
-         re-frame                  {:mvn/version "0.12.0"}
-         re-frame-steroid          {:mvn/version "0.1.1"}
-         rn-shadow-steroid         {:mvn/version "0.2.1"}
-         re-frisk-remote           {:mvn/version "1.3.3"}}
+{:deps  {org.clojure/clojure                 {:mvn/version "1.10.0"}
+         org.clojure/clojurescript           {:mvn/version "1.10.339"}
+         reagent/reagent                     {:mvn/version "0.10.0"}
+         re-frame/re-frame                   {:mvn/version "0.12.0"}
+         re-frame-steroid/re-frame-steroid   {:mvn/version "0.1.1"}
+         rn-shadow-steroid/rn-shadow-steroid {:mvn/version "0.2.1"}
+         re-frisk-remote/re-frisk-remote     {:mvn/version "1.3.3"}}
  :paths ["src" "test"]}


### PR DESCRIPTION
Unqualified lib names are being deprecated in deps.edn and will warn